### PR TITLE
serve dashboard properly

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -80,8 +80,9 @@ module.exports = {
   BridgeShardAuditInterval: '5DAYS',
 
   // Local Node Dashboard and GUI
-  DashboardEnabled: '1',
+  DashboardEnabled: '0',
   DashboardPort: '8080',
+  DashboardHostname: '127.0.0.1',
 
   // Directory Server
   DirectoryStorageBaseDir: datadir,

--- a/bin/orc.js
+++ b/bin/orc.js
@@ -247,17 +247,20 @@ function join() {
 }
 
 // Configure dashboard and check enabled
-function dashboard() {
-  if (config.DashboardEnabled) {
-    return new orc.dashboard({
-      logger,
-      port: config.DashboardPort
-    });
-  }
+if (parseInt(config.DashboardEnabled)) {
+  const dashboard = new orc.Dashboard({ logger });
+
+  dashboard.listen(
+    parseInt(config.DashboardPort),
+    config.DashboardHostname,
+    () => {
+      logger.info(
+        `gui listening on ${config.DashboardHostname}:${config.DashboardPort}`
+      );
+    }
+  );
 }
 
-// Initiate dashboard
-dashboard();
 
 function profiles() {
   if (config.ProfilesEnabled.length === 0) {

--- a/index.js
+++ b/index.js
@@ -98,8 +98,8 @@ module.exports.constants = require('./lib/constants');
 /** {@link module:orc/profiles} */
 module.exports.profiles = require('./lib/profiles');
 
-/** {@link module:orc/dashboard} */
-module.exports.dashboard = require('./lib/dashboard');
+/** {@link Dashboard} */
+module.exports.Dashboard = require('./lib/dashboard');
 
 /** {@link module:orc/utils} */
 module.exports.utils = require('./lib/utils');

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -1,42 +1,48 @@
 'use strict';
 
+const path = require('path');
 const http = require('http');
 const serveStatic = require('serve-static');
 const finalhandler = require('finalhandler');
 
+
+/**
+ * Creates and serves a web application frontend for managing an ORC node
+ */
 class Dashboard {
+
+  /**
+   * @constructor
+   * @param {object} options
+   * @param {object} options.logger
+   */
   constructor(options) {
     this.logger = options.logger;
-    this.app(options.port);
+    this.server = this._createServer();
   }
 
-  app(port) {
-    const self = this;
-    const serve = serveStatic('../gui/');
-    const server = http.createServer(function(req, res) {
-      serve(req, res, finalhandler(req, res));
+  /**
+   * @private
+   */
+  _createServer() {
+    const handler = serveStatic(path.join(__dirname, '../gui'));
+    const server = http.createServer((req, res) => {
+      handler(req, res, finalhandler(req, res));
     });
 
-    server.listen(port, function() {
-      self.logger.info(`orc gui being served on ${port}`);
-    });
+    return server;
   }
 
-  error(err, req, res, next) {
-    if (!err) {
-      return next();
-    }
-
-    this.logger.warn(`error in gui: ${err}`);
-
-    res.writeHead(err.code || 500);
-    res.write(err.message);
-    res.end();
+  /**
+   * Start the server on the supplied port
+   * @param {number} port
+   * @param {string} hostname
+   * @param {function} callback
+   */
+  listen() {
+    this.server.listen(...arguments);
   }
 
-  authenticate(req, res, next) {
-    return next();
-  }
 }
 
 


### PR DESCRIPTION
Some notes:

* Disables the dashboard by default - we want users to explicitly enable in the config so as not to inadvertently expose any ports they are unaware of
* Adds hostname to config - we always want to bind to a loopback by default else users can be de-anonymized if the machine is exposed to the internet
* Moved the listening to a method, we shouldn't ever let constructors have side effects if it can be helped